### PR TITLE
Update sbt version to be compatible with Java 10 @ Mac

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.2.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
 sbt.version=1.2.1
+scalaVersion=2.12.6


### PR DESCRIPTION
Old version sbt cannot import project with Java 10 on MacOS.
Update to newer one.